### PR TITLE
Support for up to 2 bytes per label

### DIFF
--- a/PcdReader.cs
+++ b/PcdReader.cs
@@ -249,14 +249,19 @@ class PcdReader
 
                     if (isLabelAvailable)
                     {
-                        if (labelsSize == 4)
-                        {
-                            point.label = BitConverter.ToUInt32(bytes, byteId + labelOffset);
-                        }
-                        else if (labelsSize == 1)
+                        if (labelsSize == 1)
                         {
                             point.label = bytes[byteId + labelOffset];
                         }
+                        else if (labelsSize == 2)
+                        {
+                            point.label = BitConverter.ToUInt16(bytes, byteId + labelOffset);
+                        }
+                        else if (labelsSize == 4)
+                        {
+                            point.label = (UInt16)BitConverter.ToUInt32(bytes, byteId + labelOffset);
+                        }
+
                     }
 
                     if ((pointIndex + 1) == pointCount)
@@ -350,7 +355,7 @@ struct Point3D
 
     public uint colorRGB;
 
-    public uint label;
+    public UInt16 label;
 }
 
 /// <summary>

--- a/PcdReader.cs
+++ b/PcdReader.cs
@@ -212,6 +212,7 @@ class PcdReader
         var restOfFields = fields.Except(new string[] { "x", "y", "z", "rgb" });
         var isLabelAvailable = restOfFields.Contains("label");
         var labelOffset = GetFieldOffset("label", fields, sizes);
+        var labelsSize = sizes.ElementAt(fields.IndexOf("label"));
         var pointIndex = 0;
 
 
@@ -246,8 +247,14 @@ class PcdReader
 
                     if (isLabelAvailable)
                     {
-                        // TODO support types appart from byte
-                        point.label = bytes[byteId + labelOffset];
+                        if (labelsSize == 4)
+                        {
+                            point.label = BitConverter.ToUInt32(bytes, byteId + labelOffset);
+                        }
+                        else if (labelsSize == 1)
+                        {
+                            point.label = bytes[byteId + labelOffset];
+                        }
                     }
 
                     if ((pointIndex + 1) == pointCount)
@@ -341,7 +348,7 @@ struct Point3D
 
     public uint colorRGB;
 
-    public byte label;
+    public uint label;
 }
 
 /// <summary>

--- a/PcdReader.cs
+++ b/PcdReader.cs
@@ -3,6 +3,8 @@
 // </auto-generated>
 
 // PCD file format: https://pcl.readthedocs.io/projects/tutorials/en/master/pcd_file_format.html#pcd-file-format
+using System.Runtime.CompilerServices;
+
 class PcdReader
 {
     private Header header;
@@ -133,6 +135,22 @@ class PcdReader
 
         return newLineBytesLength;
     }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ReadLabel(ref Point3D point, ref byte[] bytes, int byteId, int labelOffset, int labelsSize)
+    {
+        if (labelsSize == 1)
+        {
+            point.label = bytes[byteId + labelOffset];
+        }
+        else if (labelsSize == 2)
+        {
+            point.label = BitConverter.ToUInt16(bytes, byteId + labelOffset);
+        }
+        else if (labelsSize == 4)
+        {
+            throw new NotImplementedException("Sorry, label size of 4 bytes is not currently supported.");
+        }
+    }
 
     private void ReadBinaryCompressedData(byte[] bytes, int rowSizeBytes, int index)
     {
@@ -249,19 +267,7 @@ class PcdReader
 
                     if (isLabelAvailable)
                     {
-                        if (labelsSize == 1)
-                        {
-                            point.label = bytes[byteId + labelOffset];
-                        }
-                        else if (labelsSize == 2)
-                        {
-                            point.label = BitConverter.ToUInt16(bytes, byteId + labelOffset);
-                        }
-                        else if (labelsSize == 4)
-                        {
-                            point.label = (UInt16)BitConverter.ToUInt32(bytes, byteId + labelOffset);
-                        }
-
+                        ReadLabel(ref point, ref bytes, byteId, labelOffset, labelsSize);
                     }
 
                     if ((pointIndex + 1) == pointCount)

--- a/PcdReader.cs
+++ b/PcdReader.cs
@@ -212,7 +212,9 @@ class PcdReader
         var restOfFields = fields.Except(new string[] { "x", "y", "z", "rgb" });
         var isLabelAvailable = restOfFields.Contains("label");
         var labelOffset = GetFieldOffset("label", fields, sizes);
-        var labelsSize = sizes.ElementAt(fields.IndexOf("label"));
+        int labelsSize = 0;
+        if (isLabelAvailable)
+            labelsSize = sizes.ElementAt(fields.IndexOf("label"));
         var pointIndex = 0;
 
 


### PR DESCRIPTION
This pull request includes changes to the `PcdReader.cs` file to improve the handling of label sizes and update the `Point3D` structure. The most important changes include adding support for different label sizes and modifying the `Point3D` structure to accommodate these changes.

Improvements to label size handling:

* [`PcdReader.cs`](diffhunk://#diff-03583339d2ac580b02903c4ad120668669bbed7434b55676c9c13eed5ca508adR215-R217): Added a check for `label` size and assigned the appropriate size based on the field's size in `ReadBinaryData` method.
* [`PcdReader.cs`](diffhunk://#diff-03583339d2ac580b02903c4ad120668669bbed7434b55676c9c13eed5ca508adL249-R265): Added support for `label` sizes of 2 and 4 bytes in the `ReadBinaryData` method, allowing the conversion of bytes to `UInt16` and `UInt32` respectively.

Updates to `Point3D` structure:

* [`PcdReader.cs`](diffhunk://#diff-03583339d2ac580b02903c4ad120668669bbed7434b55676c9c13eed5ca508adL344-R358): Changed the `label` field in the `Point3D` structure from `byte` to `UInt16` to support larger label sizes.